### PR TITLE
persist database connection between tests

### DIFF
--- a/testconfig.js
+++ b/testconfig.js
@@ -27,9 +27,9 @@ beforeEach(async done => {
   }
 })
 afterEach(done => {
-  mongoose.disconnect()
   return done()
 })
 afterAll(done => {
+  mongoose.disconnect()
   return done()
 })


### PR DESCRIPTION
When running tests on exercises/models an error stops the tests due to `MongoError: pool is draining, new operations prohibited`. Refactored testconfig.js to execute `mongoose.disconnect()` after all the tests have been completed instead of after each test.