### PR TITLE
org schema: status default value should be a string

### DIFF
--- a/exercises/hooks/org.js
+++ b/exercises/hooks/org.js
@@ -12,7 +12,7 @@ const orgSchema = new mongoose.Schema({
     status: {
       type: String,
       required: true,
-      default: ['active'],
+      default: 'active',
       enum: ['active', 'trialing', 'overdue', 'canceled']
     },
     last4: {


### PR DESCRIPTION
I had the following problem with hooks part - running tests would fail with error: `CastError: Cast to string failed for value "[ 'active' ]" at path "subscription.status"`. This PR should fix the issue.